### PR TITLE
(docs): fix typo and punctuation in `docs/api.rst`

### DIFF
--- a/docs/source/drum/api.rst
+++ b/docs/source/drum/api.rst
@@ -44,11 +44,11 @@ Settings
 ########
 Below are the default settings for building the drum model. It will be loaded
 by the class :class:`omnizart.setting_loaders.DrumSettings`. The name of the
-attributes will be converted to snake-case (e.g. HopSize -> hop_size). There
+attributes will be converted to snake-case (e.g., HopSize -> hop_size). There
 is also a path transformation process when applying the settings into the
 ``DrumSettings`` instance. For example, if you want to access the attribute
 ``BatchSize`` defined in the yaml path *General/Training/Settings/BatchSize*,
-the coressponding attribute will be *DrumSettings.training.batch_size*.
+the corresponding attribute will be *DrumSettings.training.batch_size*.
 The level of */Settings* is removed among all fields.
 
 .. literalinclude:: ../../../omnizart/defaults/drum.yaml


### PR DESCRIPTION
- fix typo
- add punctuation