### PR TITLE
(docs): update all docs

### DIFF
--- a/docs/source/add-new-modules.rst
+++ b/docs/source/add-new-modules.rst
@@ -20,7 +20,7 @@ Principles
   small part of them to adapt to your task.
 * **Try not to make your own wheels** - There have been many useful and validated functions that are
   developed to deal with the daily works. They are already there to cover 90% of every details of a
-  module, thus new logics are in very small chances being needed. 
+  module, thus new logics are in very small chances being needed.
   Most of the time you need to implement the most would be the part of feature and label extraction,
   which will be explained in the upcoming sections.
 * **Check with linters frequently** - You should always do ``make lint`` before you push to github,
@@ -30,11 +30,11 @@ Principles
   saves lots of time fixing those lint errors. But it should not be the main concern now, as the
   architecture is more stable and less error prone. You should follow every hints by the linters
   and fix them before you file a pull request.
- 
+
 
 ----
 
-So now we are all set and ready to add a new module to omnizart. Here we will take the 
+So now we are all set and ready to add a new module to omnizart. Here we will take the
 `PR #11 <https://github.com/Music-and-Culture-Technology-Lab/omnizart/pull/11>`_ as the example.
 
 Setup
@@ -74,9 +74,9 @@ Critical Files/Functions
 * `omnizart.patch_cnn.app.extract_label <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/patch_cnn/app.py#L278-L327>`_
   - The function for label extraction, generating the representation of ground-truth. Accepts the path to the ground-truth file, parses the contents
   into intermediate format (see :class:`omnizart.base.Label`), and extracts necessary informations.
-  
+
   Normally, it should be defined in a separate file called ``labels.py`` under *omnizart/<module>/* when the extraction process contains lots of logics.
-  Since the label extraction in this example is relativly simple, it is okay to put it under ``omnizart.patch_cnn.app``.
+  Since the label extraction in this example is relatively simple, it is okay to put it under ``omnizart.patch_cnn.app``.
   See the conventional case :class:`omnizart.drum.labels`.
 
 * `omnizart.patch_cnn._parallel_feature_extraction <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/patch_cnn/app.py#L336-L373>`_
@@ -96,7 +96,7 @@ Overall Process Flow
 
 1. Determine the dataset type from the given dataset path.
     * `music module <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/master/omnizart/music/app.py#L169-L179>`_
-2. Choose the coressponding dataset strcuture class.
+2. Choose the corresponding dataset structure class.
     * `patch-cnn <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/patch_cnn/app.py#L135>`_
     * `music module <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/master/omnizart/music/app.py#L182-L186>`_
 3. Parse audio/ground-truth file pairs.
@@ -134,14 +134,14 @@ Critical Files/Functions
 
 * `omnizart.patch_cnn.app.PatchCNNDatasetLoader <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/patch_cnn/app.py#L376-L380>`_
   - The dataset loader for feeding data to models. Dealing with listing files, iterating through all feature/label pairs,
-  indexing, and additionally augmenting, cliping, or transforming the feature/label on the fly.
+  indexing, and additionally augmenting, clipping, or transforming the feature/label on the fly.
 
 * `omnizart.setting_loaders.PatchCNNSettings <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/setting_loaders.py#L366-L386>`_
   - The data class that holds the necessary hyper parameters that will be used by different functions of this module. For model training,
   related hyper parameters are registered under ``PatchCNNSettings.dataset``, ``PatchCNNSettings.model``, and
   ``PatchCNNSettings.training`` attributes.
 
-* `omnizart/defatuls/patch_cnn.yaml (1) <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/checkpoints/patch_cnn/patch_cnn_melody/configurations.yaml#L54-L75>`_ / 
+* `omnizart/defatuls/patch_cnn.yaml (1) <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/checkpoints/patch_cnn/patch_cnn_melody/configurations.yaml#L54-L75>`_ /
   `omnizart/defatuls/patch_cnn.yaml (2) <https://github.com/Music-and-Culture-Technology-Lab/omnizart/blob/273fc60fbc6e3728c07abf71e06cf8f092bfabeb/omnizart/checkpoints/patch_cnn/patch_cnn_melody/configurations.yaml#L88-L118>`_
   - The configuration file of the module, records the values of hyper parameters and will be consumed by the data class (i.e. PatchCNNSettings).
 
@@ -198,5 +198,4 @@ Add new supported datasets
 If you want to add a new dataset that is currently not supported by ``omnizart`` (which is defined in
 :class:`omnizart.constants.datasets`), things should be noticed are explained in this section.
 
-(To be continue...)
-
+(To be continued...)

--- a/docs/source/beat/api.rst
+++ b/docs/source/beat/api.rst
@@ -46,11 +46,11 @@ Settings
 ########
 Below are the default settings for building the beat model. It will be loaded
 by the class :class:`omnizart.setting_loaders.BeatSettings`. The name of the
-attributes will be converted to snake-case (e.g. HopSize -> hop_size). There
+attributes will be converted to snake-case (e.g., HopSize -> hop_size). There
 is also a path transformation process when applying the settings into the
 ``BeatSettings`` instance. For example, if you want to access the attribute
 ``BatchSize`` defined in the yaml path *General/Training/Settings/BatchSize*,
-the coressponding attribute will be *BeatSettings.training.batch_size*.
+the corresponding attribute will be *BeatSettings.training.batch_size*.
 The level of */Settings* is removed among all fields.
 
 .. literalinclude:: ../../../omnizart/defaults/beat.yaml

--- a/docs/source/chord/api.rst
+++ b/docs/source/chord/api.rst
@@ -37,11 +37,11 @@ Settings
 ########
 Below are the default settings for building the chord model. It will be loaded
 by the class :class:`omnizart.setting_loaders.ChordSettings`. The name of the
-attributes will be converted to snake-case (e.g. HopSize -> hop_size). There
+attributes will be converted to snake-case (e.g., HopSize -> hop_size). There
 is also a path transformation process when applying the settings into the
 ``ChordSettings`` instance. For example, if you want to access the attribute
 ``BatchSize`` defined in the yaml path *General/Training/Settings/BatchSize*,
-the coressponding attribute will be *ChordSettings.training.batch_size*.
+the corresponding attribute will be *ChordSettings.training.batch_size*.
 The level of */Settings* is removed among all fields.
 
 .. literalinclude:: ../../../omnizart/defaults/chord.yaml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,17 +4,16 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+import sys
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-import sys
 sys.path.insert(0, os.path.abspath('../../omnizart'))
 sys.path.insert(0, os.path.abspath('../../figures'))
-
 
 # -- Project information -----------------------------------------------------
 
@@ -24,7 +23,6 @@ author = 'MCTLab'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1.0'
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -50,7 +48,6 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['bootstrap_data/*', 'tests/*']
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The name of the Pygments (syntax highlighting) style to use.
@@ -58,16 +55,14 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = 'press'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
+# so a file named 'default.css' will overwrite the builtin 'default.css'.
 html_static_path = ['_static']
 
-html_css_files = ["css/custom.css", "css/waveform-list.css"]
+html_css_files = ['css/custom.css', 'css/waveform-list.css']
 
 source_suffix = ['.py', '.rst']
 master_doc = 'index'
-

--- a/docs/source/drum/api.rst
+++ b/docs/source/drum/api.rst
@@ -44,11 +44,11 @@ Settings
 ########
 Below are the default settings for building the drum model. It will be loaded
 by the class :class:`omnizart.setting_loaders.DrumSettings`. The name of the
-attributes will be converted to snake-case (e.g. HopSize -> hop_size). There
+attributes will be converted to snake-case (e.g., HopSize -> hop_size). There
 is also a path transformation process when applying the settings into the
 ``DrumSettings`` instance. For example, if you want to access the attribute
 ``BatchSize`` defined in the yaml path *General/Training/Settings/BatchSize*,
-the coressponding attribute will be *DrumSettings.training.batch_size*.
+the corresponding attribute will be *DrumSettings.training.batch_size*.
 The level of */Settings* is removed among all fields.
 
 .. literalinclude:: ../../../omnizart/defaults/drum.yaml

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -48,7 +48,7 @@ Pyramid Net
 .. automodule:: omnizart.models.pyramid_net
     :members:
     :undoc-members:
-    :show-inferitance:
+    :show-inheritance:
 
 
 Utils

--- a/docs/source/music/api.rst
+++ b/docs/source/music/api.rst
@@ -48,11 +48,11 @@ Settings
 ########
 Below are the default settings for building the music model. It will be loaded
 by the class :class:`omnizart.setting_loaders.MusicSettings`. The name of the
-attributes will be converted to snake-case (e.g. HopSize -> hop_size). There
+attributes will be converted to snake-case (e.g., HopSize -> hop_size). There
 is also a path transformation process when applying the settings into the
 ``MusicSettings`` instance. For example, if you want to access the attribute
 ``BatchSize`` defined in the yaml path *General/Training/Settings/BatchSize*,
-the coressponding attribute will be *MusicSettings.training.batch_size*.
+the corresponding attribute will be *MusicSettings.training.batch_size*.
 The level of */Settings* is removed among all fields.
 
 .. literalinclude:: ../../../omnizart/defaults/music.yaml

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -12,7 +12,8 @@ Installation
 
 Using pip
 *********
-Omnizart is under developement and will be updated regularly on PyPI.
+
+Omnizart is under development and will be updated regularly on PyPI.
 Use ``pip`` to install the latest stable version.
 
 .. code-block:: bash
@@ -21,7 +22,7 @@ Use ``pip`` to install the latest stable version.
     # resolved automatically.
     pip install numpy Cython
 
-    # Additional system pacakges are required to fully use Omnizart.
+    # Additional system packages are required to fully use Omnizart.
     sudo apt-get install libsndfile-dev fluidsynth ffmpeg
 
     # Install Omnizart
@@ -33,14 +34,16 @@ Use ``pip`` to install the latest stable version.
 
 Development installation
 ************************
-For the development installation, clone the git repo and the installation 
+
+For the development installation, clone the git repo and the installation
 creates a virtual environment under the directory *omnizart/* by default.
 
 .. code-block:: bash
 
+    # Clone the omnizart repository from GitHub
     git clone https://github.com/Music-and-Culture-Technology-Lab/omnizart.git
 
-    # Install dependenies, with checkpoints automatically downloaded
+    # Install dependencies, with checkpoints automatically downloaded
     cd omnizart
     make install
 
@@ -51,14 +54,14 @@ creates a virtual environment under the directory *omnizart/* by default.
 CLI
 ###
 
-Below is an example usuage of pitched instrument transcription with the command-line interface, 
+Below is an example usage of pitched instrument transcription with the command-line interface,
 first transcribing a piece of music and then synthesizing the results.
 For more details and other types of transcription, refer to :doc:`tutorial`.
 
 Transcription
 *************
 
-The example transcribes a piece of music, being monophonic or polyphonic, 
+The example transcribes a piece of music, being monophonic or polyphonic,
 to a MIDI file of the transcribed pitched notes and a CSV file with more information.
 
 .. code-block:: bash

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,6 +1,6 @@
 .. Documents are written in reStructured Text (.rst) format.
    Learn the syntax from: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-   
+
    Heading Level (most significant to least):
      Underline with '='
      Underline with '#'
@@ -10,7 +10,7 @@
 Tutorial
 ========
 
-This page describes the workflow and usage of ``omnizart`` command-line interface, 
+This page describes the workflow and usage of ``omnizart`` command-line interface,
 covering core and utility.
 
 The root entry is ``omnizart`` followed by sub-commands.
@@ -28,8 +28,8 @@ In general, the core sub-commands follow a pipeline of ``application``-``action`
 where we apply an ``action`` to the ``application`` of interest, with corresponding ``arguments``.
 Detailed descriptions for the usage of each sub-command can be found in the dedicated pages for each ``application``:
 
-* :doc:`music/cli` 
-* :doc:`drum/cli` 
+* :doc:`music/cli`
+* :doc:`drum/cli`
 * :doc:`chord/cli`
 * :doc:`vocal-contour/cli`
 * :doc:`vocal/cli`
@@ -60,7 +60,7 @@ Example usage:
    # Transcribe percussive events given pop.wav, with specified model path and output directory
    omnizart drum transcribe pop.wav --model-path ./my-model --output ./trans_pop.mid
 
-Note: ``--model-path`` can be left unspecified, and the default will be the downloaded checkpoints. 
+Note: ``--model-path`` can be left unspecified, and the default will be the downloaded checkpoints.
 Execute ``omnizart download-checkpoints`` if you have not done in the installation from :doc:`quick-start`.
 
 
@@ -129,7 +129,7 @@ Utility
 Download Datasets
 *****************
 
-This sub-command belongs to the utility, used to download the datasets for training and testing the models. 
+This sub-command belongs to the utility, used to download the datasets for training and testing the models.
 Current supported datasets are:
 
 * `Maestro <https://magenta.tensorflow.org/datasets/maestro>`_ - MIDI and Audio Edited for Synchronous TRacks and Organization dataset.
@@ -147,7 +147,7 @@ Example usage:
    # Download the MAESTRO dataset and output to the */data* folder.
    omnizart download-dataset Maestro --output /data
 
-   # Downlaod the MusicNet dataset and unzip the dataset after download.
+   # Download the MusicNet dataset and unzip the dataset after download.
    omnizart download-dataset MusicNet --unzip
 
    # To see a complete list of available datasets, execute the following command

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,7 +1,7 @@
 Utilities
 =========
 
-Some common utility functionalities.
+Some common utility functions.
 
 
 Remote


### PR DESCRIPTION
- correct typos
- correct punctuation for `e.g.,`

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>