### PR TITLE
Use f-strings everywhere

### DIFF
--- a/omnizart/__init__.py
+++ b/omnizart/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 
-MODULE_PATH = os.path.abspath(__file__ + "/..")
+MODULE_PATH = os.path.abspath(f"{__file__}/..")
 SETTING_DIR = os.path.join(MODULE_PATH, "defaults")
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'

--- a/omnizart/beat/app.py
+++ b/omnizart/beat/app.py
@@ -195,7 +195,7 @@ class BeatTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -259,11 +259,11 @@ def _parallel_feature_extraction(feat_list, out_path, feat_settings, num_threads
     for idx, ((feature, beat_arr, down_beat_arr), feat_idx) in iters:
         feat = feat_list[feat_idx]
 
-        print(f"Progress: {idx+1}/{len(feat_list)} - {feat}" + " "*6, end="\r")  # noqa: E226
+        print(f"Progress: {idx + 1}/{len(feat_list)} - {feat}{' ' * 6}", end="\r")  # noqa: E226
         # logger.info("Progress: %s/%s - %s", idx+1, len(feat_list), feat)
 
         filename, _ = os.path.splitext(os.path.basename(feat))
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
         with h5py.File(out_hdf, "w") as out_f:
             out_f.create_dataset("feature", data=feature)
             out_f.create_dataset("beat", data=beat_arr)

--- a/omnizart/callbacks.py
+++ b/omnizart/callbacks.py
@@ -227,8 +227,11 @@ class TFModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
                     else:
                         if self.monitor_op(current, self.best):
                             if self.verbose > 0:
-                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} improved from {self.best:0.5f} to {current:0.5f},'
-                                      f'                                     saving model to {filepath}')
+                                print(
+                                    f"\nEpoch {int(epoch + 1):05}: {self.monitor} improved "
+                                    f"from {self.best:0.5f} to {current:0.5f},"
+                                    f"                                     saving model to {filepath}"
+                                )
 
                             self.best = current
                             if self.save_weights_only:
@@ -237,7 +240,10 @@ class TFModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
                                 self.model.save(filepath, overwrite=True, options=self._options)
                         else:
                             if self.verbose > 0:
-                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} did not improve from {self.best:0.5f}')  # noqa: E128
+                                print(
+                                    f"\nEpoch {int(epoch + 1):05}: {self.monitor} did not improve "
+                                    f"from {self.best:0.5f}"
+                                )  # noqa: E128
                 else:
                     if self.verbose > 0:
                         print(f'\nEpoch {int(epoch + 1):05}: saving model to {filepath}')

--- a/omnizart/callbacks.py
+++ b/omnizart/callbacks.py
@@ -227,8 +227,7 @@ class TFModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
                     else:
                         if self.monitor_op(current, self.best):
                             if self.verbose > 0:
-                                print('\nEpoch %05d: %s improved from %0.5f to %0.5f, \
-                                    saving model to %s' % (epoch + 1, self.monitor, self.best, current, filepath))
+                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} improved from {self.best:0.5f} to {current:0.5f},                                     saving model to {filepath}')
 
                             self.best = current
                             if self.save_weights_only:
@@ -237,11 +236,10 @@ class TFModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
                                 self.model.save(filepath, overwrite=True, options=self._options)
                         else:
                             if self.verbose > 0:
-                                print('\nEpoch %05d: %s did not improve from %0.5f' %
-                                    (epoch + 1, self.monitor, self.best))  # noqa: E128
+                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} did not improve from {self.best:0.5f}')  # noqa: E128
                 else:
                     if self.verbose > 0:
-                        print('\nEpoch %05d: saving model to %s' % (epoch + 1, filepath))
+                        print(f'\nEpoch {int(epoch + 1):05}: saving model to {filepath}')
                     if self.save_weights_only:
                         self.model.save_weights(filepath, overwrite=True, options=self._options)
                     else:

--- a/omnizart/callbacks.py
+++ b/omnizart/callbacks.py
@@ -227,7 +227,8 @@ class TFModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
                     else:
                         if self.monitor_op(current, self.best):
                             if self.verbose > 0:
-                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} improved from {self.best:0.5f} to {current:0.5f},                                     saving model to {filepath}')
+                                print(f'\nEpoch {int(epoch + 1):05}: {self.monitor} improved from {self.best:0.5f} to {current:0.5f},'
+                                      f'                                     saving model to {filepath}')
 
                             self.best = current
                             if self.save_weights_only:

--- a/omnizart/chord/app.py
+++ b/omnizart/chord/app.py
@@ -190,7 +190,7 @@ class ChordTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -250,7 +250,7 @@ def _parallel_feature_extraction(data_pair, out_path, num_threads=4):
 
         # logger.info("Progress: %d/%d - %s", idx + 1, len(data_pair), f_name)
         print(f"Progress: {idx+1}/{len(data_pair)} - {f_name}", end="\r")
-        out_hdf = jpath(out_path, os.path.basename(f_name) + ".hdf")
+        out_hdf = jpath(out_path, f"{os.path.basename(f_name)}.hdf")
         _write_feature(feature, out_path=out_hdf)
 
 

--- a/omnizart/chord/features.py
+++ b/omnizart/chord/features.py
@@ -72,7 +72,7 @@ def load_feature(feat_path, label):
         root = chord.split(":")[0]
         if "b" in root:
             root, quality = chord.split(':')
-            chord = ENHARMONIC_TABLE[root] + ':' + quality
+            chord = f"{ENHARMONIC_TABLE[root]}:{quality}"
         chord_int = CHORD_INT_MAPPING[chord]
         chord_change = 0 if chord_int == pre_chord else 1
         pre_chord = chord_int

--- a/omnizart/cli/cli.py
+++ b/omnizart/cli/cli.py
@@ -105,46 +105,46 @@ def download_dataset(dataset, output):
 @click.option("--output-path", help="Explicitly specify the path to the omnizart project for storing checkpoints.")
 def download_checkpoints(output_path):
     """Download the archived checkpoints of different models."""
-    release_url = "https://github.com/Music-and-Culture-Technology-Lab/omnizart/releases/download/checkpoints-20211001/"
+    release_url = "https://github.com/Music-and-Culture-Technology-Lab/omnizart/releases/download/checkpoints-20211001"
     CHECKPOINTS = {
         "chord_v1": {
-            "fid": f"{release_url}chord_v1@variables.data-00000-of-00001",
+            "fid": f"{release_url}/chord_v1@variables.data-00000-of-00001",
             "save_as": "checkpoints/chord/chord_v1/variables/variables.data-00000-of-00001"
         },
         "drum_keras": {
-            "fid": f"{release_url}drum_keras@variables.data-00000-of-00001",
+            "fid": f"{release_url}/drum_keras@variables.data-00000-of-00001",
             "save_as": "checkpoints/drum/drum_keras/variables/variables.data-00000-of-00001",
         },
         "music_pop": {
-            "fid": f"{release_url}music_pop@variables.data-00000-of-00001",
+            "fid": f"{release_url}/music_pop@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_pop/variables/variables.data-00000-of-00001",
         },
         "music_piano": {
-            "fid": f"{release_url}music_piano@variables.data-00000-of-00001",
+            "fid": f"{release_url}/music_piano@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_piano/variables/variables.data-00000-of-00001",
         },
         "music_piano-v2": {
-            "fid": f"{release_url}music_piano-v2@variables.data-00000-of-00001",
+            "fid": f"{release_url}/music_piano-v2@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_piano-v2/variables/variables.data-00000-of-00001",
         },
         "music_note_stream": {
-            "fid": f"{release_url}music_note_stream@variables.data-00000-of-00001",
+            "fid": f"{release_url}/music_note_stream@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_note_stream/variables/variables.data-00000-of-00001",
         },
         "vocal_semi": {
-            "fid": f"{release_url}vocal_semi@variables.data-00000-of-00001",
+            "fid": f"{release_url}/vocal_semi@variables.data-00000-of-00001",
             "save_as": "checkpoints/vocal/vocal_semi/variables/variables.data-00000-of-00001",
         },
         "vocal_contour": {
-            "fid": f"{release_url}contour@variables.data-00000-of-00001",
+            "fid": f"{release_url}/contour@variables.data-00000-of-00001",
             "save_as": "checkpoints/vocal/vocal_contour/variables/variables.data-00000-of-00001",
         },
         "beat": {
-            "fid": f"{release_url}beat_blstm@variables.data-00000-of-00001",
+            "fid": f"{release_url}/beat_blstm@variables.data-00000-of-00001",
             "save_as": "checkpoints/beat/beat_blstm/variables/variables.data-00000-of-00001",
         },
         "patch_cnn_melody": {
-            "fid": f"{release_url}patch_cnn_melody@variables.data-00000-of-00001",
+            "fid": f"{release_url}/patch_cnn_melody@variables.data-00000-of-00001",
             "save_as": "checkpoints/patch_cnn/patch_cnn_melody/variables/variables.data-00000-of-00001",
         }
     }

--- a/omnizart/cli/cli.py
+++ b/omnizart/cli/cli.py
@@ -108,43 +108,43 @@ def download_checkpoints(output_path):
     release_url = "https://github.com/Music-and-Culture-Technology-Lab/omnizart/releases/download/checkpoints-20211001/"
     CHECKPOINTS = {
         "chord_v1": {
-            "fid": release_url + "chord_v1@variables.data-00000-of-00001",
+            "fid": f"{release_url}chord_v1@variables.data-00000-of-00001",
             "save_as": "checkpoints/chord/chord_v1/variables/variables.data-00000-of-00001"
         },
         "drum_keras": {
-            "fid": release_url + "drum_keras@variables.data-00000-of-00001",
+            "fid": f"{release_url}drum_keras@variables.data-00000-of-00001",
             "save_as": "checkpoints/drum/drum_keras/variables/variables.data-00000-of-00001",
         },
         "music_pop": {
-            "fid": release_url + "music_pop@variables.data-00000-of-00001",
+            "fid": f"{release_url}music_pop@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_pop/variables/variables.data-00000-of-00001",
         },
         "music_piano": {
-            "fid": release_url + "music_piano@variables.data-00000-of-00001",
+            "fid": f"{release_url}music_piano@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_piano/variables/variables.data-00000-of-00001",
         },
         "music_piano-v2": {
-            "fid": release_url + "music_piano-v2@variables.data-00000-of-00001",
+            "fid": f"{release_url}music_piano-v2@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_piano-v2/variables/variables.data-00000-of-00001",
         },
         "music_note_stream": {
-            "fid": release_url + "music_note_stream@variables.data-00000-of-00001",
+            "fid": f"{release_url}music_note_stream@variables.data-00000-of-00001",
             "save_as": "checkpoints/music/music_note_stream/variables/variables.data-00000-of-00001",
         },
         "vocal_semi": {
-            "fid": release_url + "vocal_semi@variables.data-00000-of-00001",
+            "fid": f"{release_url}vocal_semi@variables.data-00000-of-00001",
             "save_as": "checkpoints/vocal/vocal_semi/variables/variables.data-00000-of-00001",
         },
         "vocal_contour": {
-            "fid": release_url + "contour@variables.data-00000-of-00001",
+            "fid": f"{release_url}contour@variables.data-00000-of-00001",
             "save_as": "checkpoints/vocal/vocal_contour/variables/variables.data-00000-of-00001",
         },
         "beat": {
-            "fid": release_url + "beat_blstm@variables.data-00000-of-00001",
+            "fid": f"{release_url}beat_blstm@variables.data-00000-of-00001",
             "save_as": "checkpoints/beat/beat_blstm/variables/variables.data-00000-of-00001",
         },
         "patch_cnn_melody": {
-            "fid": release_url + "patch_cnn_melody@variables.data-00000-of-00001",
+            "fid": f"{release_url}patch_cnn_melody@variables.data-00000-of-00001",
             "save_as": "checkpoints/patch_cnn/patch_cnn_melody/variables/variables.data-00000-of-00001",
         }
     }

--- a/omnizart/constants/datasets.py
+++ b/omnizart/constants/datasets.py
@@ -165,7 +165,7 @@ class BaseStructure:
         or filter out some files.
         """
         ensure_path_exists(save_path)
-        save_name = f"{cls.__name__.replace('Structure', '')}.zip"
+        save_name = cls.__name__.replace("Structure", "") + ".zip"
         dataset_path, unzip_done = download_large_file_from_google_drive(
             cls.url, save_path=save_path, save_name=save_name, unzip=True
         )

--- a/omnizart/constants/datasets.py
+++ b/omnizart/constants/datasets.py
@@ -45,7 +45,7 @@ logger = get_logger("Constant Datasets")
 def _get_file_list(dataset_path, dirs, ext):
     files = []
     for _dir in dirs:
-        files += glob.glob(os.path.join(dataset_path, _dir, "*" + ext))
+        files += glob.glob(os.path.join(dataset_path, _dir, f"*{ext}"))
     return files
 
 
@@ -165,7 +165,7 @@ class BaseStructure:
         or filter out some files.
         """
         ensure_path_exists(save_path)
-        save_name = cls.__name__.replace("Structure", "") + ".zip"
+        save_name = f"{cls.__name__.replace('Structure', '')}.zip"
         dataset_path, unzip_done = download_large_file_from_google_drive(
             cls.url, save_path=save_path, save_name=save_name, unzip=True
         )
@@ -430,7 +430,7 @@ class McGillBillBoard(BaseStructure):
         for data in reader:
             pid = int(data["id"])
             if data["title"] != "" and pid not in cls.ignore_ids:
-                name = data["artist"] + ": " + data["title"]
+                name = f"{data['artist']}: {data['title']}"
                 if name not in name_id_mapping:
                     name_id_mapping[name] = []
                 name_id_mapping[name].append(pid)  # Repetition count: 1->613, 2->110, 3->19

--- a/omnizart/drum/app.py
+++ b/omnizart/drum/app.py
@@ -203,7 +203,7 @@ class DrumTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -250,7 +250,7 @@ def _parallel_feature_extraction(wav_paths, label_paths, out_path, feat_settings
 
         basename = os.path.basename(audio)
         filename, _ = os.path.splitext(basename)
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
 
         saved = False
         retry_times = 5
@@ -300,7 +300,7 @@ def _parallel_feature_extraction_v2(data_pair, out_path, feat_settings, num_thre
             patch_cqt, m_beat_arr, label_128, label_13, wav_path = result
             basename = os.path.basename(wav_path)
             filename, _ = os.path.splitext(basename)
-            out_hdf = jpath(out_path, filename + ".hdf")
+            out_hdf = jpath(out_path, f"{filename}.hdf")
             with h5py.File(out_hdf, "w") as out_f:
                 out_f.create_dataset("feature", data=patch_cqt, compression="gzip", compression_opts=3)
                 out_f.create_dataset("label", data=label_13, compression="gzip", compression_opts=3)

--- a/omnizart/models/spectral_norm_net.py
+++ b/omnizart/models/spectral_norm_net.py
@@ -24,8 +24,7 @@ class SpectralNormalization(tf.keras.layers.Wrapper):
         self.do_power_iteration = training
         if not isinstance(layer, tf.keras.layers.Layer):
             raise ValueError(
-                'Please initialize `TimeDistributed` layer with a '
-                '`Layer` instance. You passed: {input}'.format(input=layer)
+                f'Please initialize `TimeDistributed` layer with a `Layer` instance. You passed: {layer}'
             )
         super().__init__(layer, **kwargs)
 

--- a/omnizart/models/t2t.py
+++ b/omnizart/models/t2t.py
@@ -327,7 +327,7 @@ def dot_product_attention(
         weights = cast_like(weights, q)
         if save_weights_to is not None:
             save_weights_to[scope.name] = weights
-            save_weights_to[scope.name + "/logits"] = logits
+            save_weights_to[f"{scope.name}/logits"] = logits
         # Drop out attention links for each head.
         weights = dropout_with_broadcast_dims(weights, 1.0 - dropout_rate, broadcast_dims=dropout_broadcast_dims)
         return tf.matmul(weights, v)

--- a/omnizart/music/app.py
+++ b/omnizart/music/app.py
@@ -314,7 +314,7 @@ class MusicTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -367,11 +367,11 @@ def _parallel_feature_extraction(audio_list, out_path, feat_settings, num_thread
     for idx, (feature, audio_idx) in iters:
         audio = audio_list[audio_idx]
         # logger.info("Progress: %s/%s - %s", idx+1, len(audio_list), audio)
-        print(f"Progress: {idx+1}/{len(audio_list)} - {audio}" + " "*6, end="\r")  # noqa: E226
+        print(f"Progress: {idx + 1}/{len(audio_list)} - {audio}{' ' * 6}", end="\r")  # noqa: E226
 
         basename = os.path.basename(audio)
         filename, _ = os.path.splitext(basename)
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
 
         saved = False
         retry_times = 5

--- a/omnizart/music/inference.py
+++ b/omnizart/music/inference.py
@@ -464,9 +464,7 @@ def multi_inst_note_inference(
             ent += entropy(cha)
             normed_ch.append(cha)
 
-        confidence = "std: {:.3f} ent: {:.3f} mult: {:.3f}".format(
-            std / ch_per_inst, ent / ch_per_inst, std * ent / ch_per_inst**2
-        )
+        confidence = f"std: {std / ch_per_inst:.3f} ent: {ent / ch_per_inst:.3f} mult: {std * ent / ch_per_inst ** 2:.3f}"
         logger.debug("Instrument confidence: %s", confidence)
         if iters > 1 and (std / ch_per_inst < inst_th):
             # Filter out instruments that the confidence is under the given threshold

--- a/omnizart/music/inference.py
+++ b/omnizart/music/inference.py
@@ -464,7 +464,11 @@ def multi_inst_note_inference(
             ent += entropy(cha)
             normed_ch.append(cha)
 
-        confidence = f"std: {std / ch_per_inst:.3f} ent: {ent / ch_per_inst:.3f} mult: {std * ent / ch_per_inst ** 2:.3f}"
+        confidence = (
+            f"std: {std / ch_per_inst:.3f} "
+            f"ent: {ent / ch_per_inst:.3f} "
+            f"mult: {std * ent / ch_per_inst ** 2:.3f}"
+        )
         logger.debug("Instrument confidence: %s", confidence)
         if iters > 1 and (std / ch_per_inst < inst_th):
             # Filter out instruments that the confidence is under the given threshold

--- a/omnizart/music/labels.py
+++ b/omnizart/music/labels.py
@@ -250,12 +250,12 @@ class BaseLabelExtraction(metaclass=abc.ABCMeta):
             probabilities will be in a 'fade-out' manner until the note offset.
         """
         for idx, label_path in enumerate(label_list):
-            print(f"Progress: {idx+1}/{len(label_list)} - {label_path}" + " "*6, end="\r")  # noqa: E226
+            print(f"Progress: {idx + 1}/{len(label_list)} - {label_path}{' ' * 6}", end="\r")  # noqa: E226
             label_obj = cls.extract_label(label_path, t_unit=t_unit, onset_len_sec=onset_len_sec)
             basename = os.path.basename(label_path)  # File name with extension
             filename, _ = os.path.splitext(basename)  # File name without extension
             output_name = cls.name_transform(filename)  # Output the same name as feature file
-            output_path = os.path.join(out_path, output_name + ".pickle")
+            output_path = os.path.join(out_path, f"{output_name}.pickle")
             dump_pickle(label_obj, output_path)
         print("")
 

--- a/omnizart/patch_cnn/app.py
+++ b/omnizart/patch_cnn/app.py
@@ -246,7 +246,7 @@ class PatchCNNTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -363,7 +363,7 @@ def _parallel_feature_extraction(data_pair_list, out_path, feat_settings, num_th
         print(f"Progress: {idx + 1}/{len(data_pair_list)} - {audio}", end="\r")
 
         filename = get_filename(audio)
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
         with h5py.File(out_hdf, "w") as out_f:
             out_f.create_dataset("feature", data=feat)
             out_f.create_dataset("mapping", data=mapping)

--- a/omnizart/vocal/app.py
+++ b/omnizart/vocal/app.py
@@ -297,7 +297,7 @@ class VocalTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
         write_yaml(settings.to_json(), jpath(model_save_path, "configurations.yaml"))
@@ -377,7 +377,7 @@ def _vocal_separation(wav_list, out_folder):
             fname, _ = os.path.splitext(os.path.basename(wav_path))
             sep_folder = jpath(out_folder, fname)
             vocal_track = jpath(sep_folder, "vocals.wav")
-            shutil.move(vocal_track, jpath(out_folder, fname + ".wav"))
+            shutil.move(vocal_track, jpath(out_folder, f"{fname}.wav"))
             shutil.rmtree(sep_folder)
     return out_list
 
@@ -426,7 +426,7 @@ def _parallel_feature_extraction(
 
         basename = os.path.basename(audio)
         filename, _ = os.path.splitext(basename)
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
         with h5py.File(out_hdf, "w") as out_f:
             out_f.create_dataset("feature", data=feature, compression="gzip", compression_opts=3)
             out_f.create_dataset("label", data=label, compression="gzip", compression_opts=3)

--- a/omnizart/vocal_contour/app.py
+++ b/omnizart/vocal_contour/app.py
@@ -231,7 +231,7 @@ class VocalContourTranscription(BaseTranscription):
         if model_name is None:
             model_name = str(datetime.now()).replace(" ", "_")
         if not model_name.startswith(settings.model.save_prefix):
-            model_name = settings.model.save_prefix + "_" + model_name
+            model_name = f"{settings.model.save_prefix}_{model_name}"
 
         model_save_path = jpath(settings.model.save_path, model_name)
         ensure_path_exists(model_save_path)
@@ -296,10 +296,10 @@ def _parallel_feature_extraction(data_pair, out_path, label_extractor, feat_sett
     for idx, ((feature, label), audio_idx) in iters:
         audio = data_pair[audio_idx][0]
 
-        print(f"Progress: {idx+1}/{len(data_pair)} - {audio}" + " "*6, end="\r")  # noqa: E226
+        print(f"Progress: {idx + 1}/{len(data_pair)} - {audio}{' ' * 6}", end="\r")  # noqa: E226
 
         filename, _ = os.path.splitext(os.path.basename(audio))
-        out_hdf = jpath(out_path, filename + ".hdf")
+        out_hdf = jpath(out_path, f"{filename}.hdf")
         saved = False
         retry_times = 5
         for retry in range(retry_times):


### PR DESCRIPTION
This converts all string concatenations, `%` syntax and `format` calls to use [f-strings](https://peps.python.org/pep-0498/), which is available from Python 3.6+. I used [flynt](https://github.com/ikamensh/flynt) to make the conversion automatically (`flynt -ll 1000 -tc -a .`). EDIT: this probably overlaps a bit with #67.

(As a bonus, using [f-strings can sometimes improve performance](https://github.com/cclib/cclib/pull/1121#issue-1181418010) since it's built into the syntax and fewer function calls are required. I haven't tested that here though.)