### PR TITLE
fix: broken workflow

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -50,7 +50,6 @@ jobs:
           sudo apt-get install libsndfile1 ffmpeg
           export DEFAULT_INSTALL_APPROACH=pip
           ./scripts/install.sh
-          pip install -U numpy
           omnizart download-checkpoints --output-path ./
           pip install flake8 pylint pytest pytest-cov pytest-mock
       - name: Check with linters

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -48,9 +48,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsndfile1 ffmpeg
-          if [ ${{ matrix.python-version }} = "3.7" ]; then
-            export DEFAULT_INSTALL_APPROACH=pip
-          fi
+          export DEFAULT_INSTALL_APPROACH=pip
           ./scripts/install.sh
           omnizart download-checkpoints --output-path ./
           pip install flake8 pylint pytest pytest-cov pytest-mock

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -50,6 +50,7 @@ jobs:
           sudo apt-get install libsndfile1 ffmpeg
           export DEFAULT_INSTALL_APPROACH=pip
           ./scripts/install.sh
+          pip install -U numpy
           omnizart download-checkpoints --output-path ./
           pip install flake8 pylint pytest pytest-cov pytest-mock
       - name: Check with linters

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libsndfile1 ffmpeg
-          if [ ${{ matrix.python-version }} = "3.6" ]; then
+          if [ ${{ matrix.python-version }} = "3.7" ]; then
             export DEFAULT_INSTALL_APPROACH=pip
           fi
           ./scripts/install.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,10 +60,6 @@ install_with_pip() {
     # Install some tricky packages that cannot be resolved by setup.py
     # and requirements.txt.
     pip install Cython numpy==1.19.2
-    # pip install madmom
-
-    # pip install -r requirements.txt
-    # python3 setup.py install 
     pip install .
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,7 +62,7 @@ install_with_pip() {
     pip install Cython numpy
     pip install madmom
 
-    pip install -r requirements.txt
+    # pip install -r requirements.txt
     # python3 setup.py install 
     pip install .
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,7 +59,7 @@ install_with_poetry() {
 install_with_pip() {
     # Install some tricky packages that cannot be resolved by setup.py
     # and requirements.txt.
-    pip install Cython numpy
+    pip install Cython numpy==1.19.2
     # pip install madmom
 
     # pip install -r requirements.txt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ install_with_pip() {
     # Install some tricky packages that cannot be resolved by setup.py
     # and requirements.txt.
     pip install Cython numpy
-    pip install madmom --use-feature=2020-resolver
+    pip install madmom
 
     pip install -r requirements.txt
     python3 setup.py install 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,8 +59,8 @@ install_with_poetry() {
 install_with_pip() {
     # Install some tricky packages that cannot be resolved by setup.py
     # and requirements.txt.
-    pip install Cython numpy
-    pip install madmom
+    pip install Cython #numpy
+    # pip install madmom
 
     # pip install -r requirements.txt
     # python3 setup.py install 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,9 +62,9 @@ install_with_pip() {
     pip install Cython numpy
     pip install madmom
 
-    # pip install -r requirements.txt
-    python3 setup.py install 
-    # pip install -e .
+    pip install -r requirements.txt
+    # python3 setup.py install 
+    pip install .
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,8 +62,9 @@ install_with_pip() {
     pip install Cython numpy
     pip install madmom
 
-    pip install -r requirements.txt
-    python3 setup.py install 
+    # pip install -r requirements.txt
+    # python3 setup.py install 
+    pip install -e .
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,7 +59,7 @@ install_with_poetry() {
 install_with_pip() {
     # Install some tricky packages that cannot be resolved by setup.py
     # and requirements.txt.
-    pip install Cython #numpy
+    pip install Cython numpy
     # pip install madmom
 
     # pip install -r requirements.txt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,8 +63,8 @@ install_with_pip() {
     pip install madmom
 
     # pip install -r requirements.txt
-    # python3 setup.py install 
-    pip install -e .
+    python3 setup.py install 
+    # pip install -e .
 }
 
 


### PR DESCRIPTION
The `general` workflow was broken due to the following:

- poetry. I'm sure the poetry-based installation method is broken at this point.
- The `ubuntu-latest` runner doesn't support python 3.6 anymore.

This PR is a temporary fix: replacing python 3.6 runner with 3.7, forcing pip as the default installation method.
Separate PR is needed for the poetry method.

@BreezeWhite remember to **squash** the commits before you merge.

BTW, I suggest moving the installation and unit tests into a separate workflow and only trigger on pull requests to save time.
